### PR TITLE
Variables and secrets are set on environment level, instead of repo level

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -302,15 +302,17 @@ resource "github_repository_file" "readme" {
 }
 
 # Create GitHub Actions secrets for sensitive authentication data
-resource "github_actions_secret" "gh_integration_token" {
+resource "github_actions_environment_secret" "gh_integration_token" {
   repository      = var.github_repository_name
+  environment     = local.actual_environment
   secret_name     = "GH_INTEGRATION_TOKEN"
   plaintext_value = var.github_token
 }
 
 # Create GitHub Actions variables for Terraform state backend (for debugging visibility)
-resource "github_actions_variable" "tf_state_resource_group" {
+resource "github_actions_environment_variable" "tf_state_resource_group" {
   repository    = var.github_repository_name
+  environment   = local.actual_environment
   variable_name = "TF_STATE_RESOURCE_GROUP"
   value = coalesce(
     var.terraform_state_resource_group,
@@ -319,8 +321,9 @@ resource "github_actions_variable" "tf_state_resource_group" {
   )
 }
 
-resource "github_actions_variable" "tf_state_storage_account" {
+resource "github_actions_environment_variable" "tf_state_storage_account" {
   repository    = var.github_repository_name
+  environment   = local.actual_environment
   variable_name = "TF_STATE_STORAGE_ACCOUNT"
   value = coalesce(
     var.terraform_state_storage_account != "" ? var.terraform_state_storage_account : null,
@@ -330,8 +333,9 @@ resource "github_actions_variable" "tf_state_storage_account" {
   )
 }
 
-resource "github_actions_variable" "tf_state_container" {
+resource "github_actions_environment_variable" "tf_state_container" {
   repository    = var.github_repository_name
+  environment   = local.actual_environment
   variable_name = "TF_STATE_CONTAINER"
   value = coalesce(
     var.terraform_state_container,
@@ -341,7 +345,7 @@ resource "github_actions_variable" "tf_state_container" {
 }
 
 # Create GitHub Actions variables for spoke outputs
-resource "github_actions_variable" "spoke_outputs" {
+resource "github_actions_environment_variable" "spoke_outputs" {
   for_each = {
     spoke_name           = "SPOKE_SPOKE_NAME"
     subscription_id      = "SPOKE_SUBSCRIPTION_ID"
@@ -355,6 +359,7 @@ resource "github_actions_variable" "spoke_outputs" {
   }
 
   repository    = var.github_repository_name
+  environment   = local.actual_environment
   variable_name = each.value
   value = lookup({
     spoke_name           = local.actual_spoke_name

--- a/templates/.github/workflows/terraform.yml.tpl
+++ b/templates/.github/workflows/terraform.yml.tpl
@@ -38,22 +38,14 @@ jobs:
         client-id: $${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: $${{ secrets.AZURE_TENANT_ID }}
         subscription-id: $${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    
-    - name: Set BASE_URL for GH Enterprise
-      shell: bash
-      run: |
-        BASE_URL="${GITHUB_SERVER_URL#https://}"
-        BASE_URL="${BASE_URL%/}/"
-        echo "BASE_URL=$BASE_URL" >> $GITHUB_ENV
 
     - name: Configure Git for private module access
       shell: bash
       env:
         GITHUB_TOKEN: $${{ secrets.GH_INTEGRATION_TOKEN }}
       run: |
-        git config --global url."https://${{ secrets.GH_INTEGRATION_TOKEN }}@${BASE_URL}".insteadOf "https://${BASE_URL}"
-        git config --global user.email "terraform@automation.local"
-        git config --global user.name "Terraform Automation"
+        # Replace :// with ://<token>@ to include the token in the URL
+        git config --global url."$${GITHUB_SERVER_URL/:\/\//://$GITHUB_TOKEN@}/".insteadOf "$GITHUB_SERVER_URL/"
 
     - name: Terraform Format Check
       id: fmt
@@ -64,7 +56,7 @@ jobs:
       run: |
         echo "Backend configuration:"
         echo "Resource Group: $${{ vars.TF_STATE_RESOURCE_GROUP }}"
-        echo "Storage Account: $${{ vars.TF_STATE_STORAGE_ACCOUNT }}"  
+        echo "Storage Account: $${{ vars.TF_STATE_STORAGE_ACCOUNT }}"
         echo "Container: $${{ vars.TF_STATE_CONTAINER }}"
         echo "Key: ${spoke_name}-integration.tfstate"
         # Check if variables are properly set

--- a/templates/main.tf.tpl
+++ b/templates/main.tf.tpl
@@ -8,21 +8,5 @@ module "integration_resources" {
   source = "${integration_module_source}"
 
   # Main spoke prams from the spoke creation output.
-  spoke_config = {
-    name                       = var.spoke_config.name
-    subscription_id            = var.spoke_config.subscription_id
-    resource_group_name        = var.spoke_config.resource_group_name
-    location                   = var.spoke_config.location
-    tenant_id                  = var.spoke_config.tenant_id
-    environment                = var.spoke_config.environment
-    key_vault_id               = var.spoke_config.key_vault_id
-    key_vault_name             = var.spoke_config.key_vault_name
-    storage_account_id         = var.spoke_config.storage_account_id
-    storage_account_name       = var.spoke_config.storage_account_name
-    virtual_network_id         = var.spoke_config.virtual_network_id
-    virtual_network_name       = var.spoke_config.virtual_network_name
-    tags                       = var.spoke_config.tags
-    log_analytics_workspace_id = var.spoke_config.log_analytics_workspace_id
-    log_analytics_workspace_name = var.spoke_config.log_analytics_workspace_name
-  }
+  spoke_config = var.spoke_config
 }


### PR DESCRIPTION
With this PR, the creation of Github terrafrom variables and Github Azure OIDC login secrets is done on Github environment level, instead of on repo level. This enables deployment to different Azure environments from the same Github repo, by targetting the relevant Github environment when queuing an action workflow.

Additionally, this fixes a bug with calling templatefile function on terraform.yml.tpl, by reverting (part of) last commit on this file.