### PR TITLE
Improve supply chain security and prevent workflow drift

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -195,6 +195,11 @@ resource "github_repository_file" "workflow_terraform" {
   commit_author       = "Terraform Automation"
   commit_email        = "terraform@automation.local"
   overwrite_on_create = true
+
+  # Always ignore content changes to preserve user customizations
+  lifecycle {
+    ignore_changes = [content, commit_message]
+  }
 }
 
 # Create main.tf template for integration repository
@@ -225,7 +230,7 @@ resource "github_repository_file" "variables_tf" {
   commit_email        = "terraform@automation.local"
   overwrite_on_create = false
 
-  # Ignore content changes to preserve user customizations
+  # Always ignore content changes to preserve user customizations
   lifecycle {
     ignore_changes = [content, commit_message]
   }
@@ -242,7 +247,7 @@ resource "github_repository_file" "outputs_tf" {
   commit_email        = "terraform@automation.local"
   overwrite_on_create = false
 
-  # Ignore content changes to preserve user customizations
+  # Always ignore content changes to preserve user customizations
   lifecycle {
     ignore_changes = [content, commit_message]
   }
@@ -258,6 +263,11 @@ resource "github_repository_file" "versions_tf" {
   commit_author       = "Terraform Automation"
   commit_email        = "terraform@automation.local"
   overwrite_on_create = true
+
+  # Always ignore content changes to preserve user customizations
+  lifecycle {
+    ignore_changes = [content, commit_message]
+  }
 }
 
 # Create providers.tf template for integration repository
@@ -270,6 +280,11 @@ resource "github_repository_file" "providers_tf" {
   commit_author       = "Terraform Automation"
   commit_email        = "terraform@automation.local"
   overwrite_on_create = true
+
+  # Always ignore content changes to preserve user customizations
+  lifecycle {
+    ignore_changes = [content, commit_message]
+  }
 }
 
 # Create backend.tf template for integration repository

--- a/templates/.github/workflows/terraform.yml.tpl
+++ b/templates/.github/workflows/terraform.yml.tpl
@@ -25,15 +25,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       with:
         terraform_version: ~1.9.0
 
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         client-id: $${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: $${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

- **Pin GitHub Actions to commit SHAs**: Replaces mutable version tags (`@v1`, `@v3`, `@v4`) with full commit SHAs for `actions/checkout` (v6.0.2), `hashicorp/setup-terraform` (v4.0.0), and `azure/login` (v3.0.0), eliminating the risk of tag mutation or supply chain attacks.
- **Ignore lifecycle changes on managed files**: Adds `lifecycle { ignore_changes = [content, commit_message] }` to the `github_repository_file` resources for `workflow_terraform`, `versions_tf`, and `providers_tf` — consistent with the existing pattern on `variables_tf` and `outputs_tf`. This prevents Terraform from overwriting user customizations made directly in the target repositories after initial provisioning.

## Test plan

- [ ] Run `terraform plan` against an existing integration environment and verify no unexpected changes are shown for the affected `github_repository_file` resources
- [ ] Trigger the generated workflow in a target repo and confirm all three pinned actions resolve and execute correctly
- [ ] Verify that manually edited files in a target repo are no longer overwritten on subsequent `terraform apply` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)